### PR TITLE
Basic cmd line params & detection for game path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vs
+.vscode
 */obj/
 */bin/

--- a/Rebuilder/Rebuilder.cs
+++ b/Rebuilder/Rebuilder.cs
@@ -31,6 +31,8 @@ namespace Rebuilder
 
         bool aug_build = false;
 
+        bool run_cmd = false;
+
         public static string[] standard_hdd_dirs = {
                 "C:/Program Files (x86)/LEGO Island",
                 "C:/Program Files/LEGO Island",
@@ -639,6 +641,17 @@ namespace Rebuilder
 
             if (string.IsNullOrEmpty(dir))
             {
+                // Try read games path from registry here
+                // We are assuming in this modern era the "CD" path is our game directory
+                dir = (string)Registry.GetValue("HKEY_LOCAL_MACHINE\\SOFTWARE\\Mindscape\\LEGO Island", "diskpath", null);
+                if (dir == null)
+                {
+                    dir = (string)Registry.GetValue("HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Mindscape\\LEGO Island", "diskpath", null);
+                }
+            }
+            if (string.IsNullOrEmpty(dir))
+            {
+                // Otherwise we'll prompt the user
                 using (OpenFileDialog ofd = new OpenFileDialog())
                 {
                     ofd.Filter = "ISLE.EXE|ISLE.EXE";
@@ -784,6 +797,11 @@ namespace Rebuilder
                     break;
                 }
             }
+
+            if (run_cmd) 
+            {
+                Application.Exit();
+            }
         }
 
         private void AuthorLinkClick(object sender, LinkLabelLinkClickedEventArgs e)
@@ -850,6 +868,25 @@ namespace Rebuilder
                 }
 
                 stream.Close();
+            }
+
+            // Check for any command line arguments
+            string[] arguments = Environment.GetCommandLineArgs();
+            foreach (string a in arguments)
+            {
+                switch (a)
+                {
+                    case "--help":
+                        MessageBox.Show("Supported arguments:\n\n --help\nDisplays available arguments.\n\n--run\nRuns the game immediately after starting.", "Command Line Argument Help", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    break;
+
+                    case "--run":
+                        Run(null, null);
+                    break;
+
+                    default:
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
Silly me i should have looked at some of existing pull requests first *facepalm*

Anywho I've added some additional code that will query the diskpath registry key and use this as a path to find LEGO.EXE and LEGO1.DLL.

I also added the base of some command line arguments and a single argument at this time (--run) which will run LEGO Island as soon as Rebuilder is opened.

Now i can run LEGO Island and get straight to the action!